### PR TITLE
proto: Add support for Nullable

### DIFF
--- a/proto/field.go
+++ b/proto/field.go
@@ -43,6 +43,12 @@ func (c Converter) ConvertField(field *protogen.Field) (*ConvertedField, error) 
 	case basicTypes:
 		return c.convertSimpleFields(field, typ)
 	case typ.IsArray:
+		if typ.Nullable {
+			return nil, fmt.Errorf(
+				"field %q in %q of type array cannot be marked with nullable",
+				field.Desc.Name(), field.Parent.Desc.FullName(),
+			)
+		}
 		return c.convertArrayFields(field, typ)
 	default:
 		return c.convertReferencedFields(field, typ)
@@ -209,7 +215,10 @@ func (c Converter) convertReferencedFields(field *protogen.Field, typ types.Type
 	// One-to-one relationship.
 	col := &types.Field{
 		Name: field.Desc.JSONName(),
-		Type: types.Type{Type: "int32"},
+		Type: types.Type{
+			Type:     "int32",
+			Nullable: typ.Nullable,
+		},
 	}
 	fk := types.ForeignKey{
 		Name:     parentTblName + "_" + col.Name + "_fkey",

--- a/proto/types.go
+++ b/proto/types.go
@@ -35,6 +35,7 @@ var wellKnownType = map[protoreflect.FullName]string{
 func (c Converter) goType(field *protogen.Field) (typ types.Type, simple bool, err error) {
 	simple = true
 	typ.IsArray = field.Desc.IsList()
+	typ.Nullable = fieldOpts(field).Nullable
 	if field.Desc.IsMap() {
 		// Protobuf map types will be json encoded when stored.
 		typ := types.Type{

--- a/types/sqlType.go
+++ b/types/sqlType.go
@@ -35,11 +35,9 @@ func (s sqlTypeConverter) sqlType(goType Type) xo.Type {
 		singleTyp.IsArray = true
 		return singleTyp
 	}
-	if s.Target == "sqlserver" && goType.Type == "string" {
-		// Check unique.
-	}
 	t, ok := typeMap[s.Target][goType.Type]
 	if ok {
+		t.Nullable = goType.Nullable
 		return t
 	}
 	if goType.Type != "enum" {
@@ -70,6 +68,7 @@ func (s sqlTypeConverter) buildEnum(goType Type) xo.Type {
 			enumName, maps.Keys(s.Enums),
 		))
 	}
+	typ.Nullable = goType.Nullable
 	return typ
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -81,6 +81,7 @@ type Type struct {
 	Type     string `json:"type,omitempty"`
 	IsArray  bool   `json:"array,omitempty"`
 	EnumName string `json:"enum_name,omitempty"`
+	Nullable bool   `json:"nullable,omitempty"`
 }
 
 // NewTable creates a new table with the specified name. If manual is false, a


### PR DESCRIPTION
Columns with array types may not be marked as nullable. Columns
referencing another ID will be marked nullable in the reference field.